### PR TITLE
add compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ endif
 OBJS = $(SRCS:%.cpp=%.o)
 LIB = lib$(notdir $(CURDIR)).a
 CPPFLAGS+=-g -Wall -W
+CXXFLAGS=-std=c++14
 
 lib: $(LIB)
 


### PR DESCRIPTION
If newer compilers gives you errors like this

```
Uart.h:49:64: error: ISO C++17 does not allow dynamic exception specifications
   49 |                 UART(std::string tty, bool hwflowctrl = false) throw (UARTException);
      |                                                                ^~~~~
```

you need to add the `CXXFLAGS` option to `Makefile`.